### PR TITLE
build: use node20 based actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,14 @@ jobs:
           - Release
     steps:
       - name: Check out files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
           lfs: false
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Generate project files
         run: tools/premake5 vs2022
@@ -41,7 +41,7 @@ jobs:
         run: msbuild /m /v:minimal /p:Configuration=${{matrix.configuration}} /p:Platform=x64 build/h2-mod.sln
 
       - name: Upload ${{matrix.configuration}} binaries
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.configuration}} binaries
           path: |
@@ -49,7 +49,7 @@ jobs:
             build/bin/x64/${{matrix.configuration}}/h2-mod.pdb
             
       - name: Upload ${{matrix.configuration}} data artifacts
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.configuration}} data artifacts
           path: |
@@ -69,31 +69,24 @@ jobs:
         run: echo "FED_MASTER_PATH=${{ secrets.FED_MASTER_SSH_PATH_DEV }}" >> $GITHUB_ENV
 
       - name: Download Release binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Release binaries
           
       - name: Download Release data artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Release data artifacts
           path: data
 
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v2.7.0
         with:
           key: ${{ secrets.FED_MASTER_SSH_PRIVATE_KEY }}
           known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
 
       - name: Add known hosts
         run: ssh-keyscan -H ${{ secrets.FED_MASTER_SSH_ADDRESS }} >> ~/.ssh/known_hosts
-
-      - name: Wait for previous workflows
-        uses: softprops/turnstyle@v1
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove old data files
         run: ssh ${{ secrets.FED_MASTER_SSH_USER }}@${{ secrets.FED_MASTER_SSH_ADDRESS }} rm -rf ${{ env.FED_MASTER_PATH }}/h2-mod/*


### PR DESCRIPTION
Fixes these warnings:

![image](https://github.com/user-attachments/assets/02c6438f-a81a-4361-aca7-b894424d7b21)


I also removed softprops/turnstyle@v1 because now you use 
```
concurrency:
  group: ${{ github.ref }}
  cancel-in-progress: false
```
which is already at the top of this build file
